### PR TITLE
fix: change next_state to next_event

### DIFF
--- a/lib/workflow_metal/task/task.ex
+++ b/lib/workflow_metal/task/task.ex
@@ -317,7 +317,7 @@ defmodule WorkflowMetal.Task.Task do
     {
       :keep_state,
       data,
-      {:next_state, :cast, :try_abandon_by_tokens}
+      {:next_event, :cast, :try_abandon_by_tokens}
     }
   end
 


### PR DESCRIPTION
这块跑`examples`的时候有如下报错，我试着修了下. @fahchen 你看下对不对？
```elixir
11:38:44.205 [error] GenStateMachine {TrafficLight.Workflow.LocalRegistry, {WorkflowMetal.Task.Task, {1, 9, 22, 31}}} terminating
** (ErlangError) Erlang error: {:bad_action_from_state_function, {:next_state, :cast, :try_abandon_by_tokens}}
    (stdlib 3.9) gen_statem.erl:1592: :gen_statem.loop_actions_timeout/13
    (stdlib 3.9) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
State: {:state, %{current_state: :allocated, data: %WorkflowMetal.Task.Task{application: TrafficLight.Workflow, task_schema: %WorkflowMetal.Storage.Schema.Task{case_id: 22, id: 31, state: :allocated, token_payload: nil, transition_id: 9, workflow_id: 1}, token_table: #Reference<0.4283289657.1824915457.71807>, transition_schema: %WorkflowMetal.Storage.Schema.Transition{executor: TrafficLight.R2G, executor_params: nil, id: 9, join_type: :none, split_type: :none, workflow_id: 1}, workitem_table: #Reference<0.4283289657.1824915457.71808>}}}
Callback mode: :handle_event_function
Postponed events: []
Last event: {:cast, {:discard_tokens, [%WorkflowMetal.Storage.Schema.Token{case_id: 22, consumed_by_task_id: nil, id: 29, locked_by_task_id: 30, payload: [:turn_red], place_id: 4, produced_by_task_id: 27, state: :locked, workflow_id: 1}]}}
Queued events: []
State: {:state, %{current_state: :allocated, data: %WorkflowMetal.Task.Task{application: TrafficLight.Workflow, task_schema: %WorkflowMetal.Storage.Schema.Task{case_id: 22, id: 31, state: :allocated, token_payload: nil, transition_id: 9, workflow_id: 1}, token_table: #Reference<0.4283289657.1824915457.71807>, transition_schema: %WorkflowMetal.Storage.Schema.Transition{executor: TrafficLight.R2G, executor_params: nil, id: 9, join_type: :none, split_type: :none, workflow_id: 1}, workitem_table: #Reference<0.4283289657.1824915457.71808>}}}
````